### PR TITLE
Change to a temporary directory before executing pngcrush

### DIFF
--- a/src/PHPImageOptim/Tools/Png/PngCrush.php
+++ b/src/PHPImageOptim/Tools/Png/PngCrush.php
@@ -10,12 +10,21 @@ class PngCrush extends Common implements ToolsInterface
 {
     public function optimise()
     {
+        // Pngcrush attempts to write a temporary file to the current directory;
+        // make sure we're somewhere we can write a file
+        $prevDir = getcwd();
+        chdir(sys_get_temp_dir());
+
         exec($this->binaryPath . ' -rem gAMA -rem cHRM -rem iCCP -rem sRGB -brute -q -l 9 -reduce -ow ' . escapeshellarg($this->imagePath), $aOutput, $iResult);
+
+        // Switch back to previous directory
+        chdir($prevDir);
 
         if ($iResult != 0)
         {
             throw new Exception('PNGCrush was unable  to optimise image, result:' . $iResult . ' File: ' . $this->imagePath);
         }
+
         return $this;
     }
 


### PR DESCRIPTION
Pngcrush writes temporary files in the current working directory.
Sometimes the user running PHP does not have write permissions in the
current working directory, so change to a temporary directory first,
then change back afterwards.

See #2 