### PR TITLE
Fix mozjpeg support

### DIFF
--- a/src/PHPImageOptim/Tools/Jpeg/MozJpeg.php
+++ b/src/PHPImageOptim/Tools/Jpeg/MozJpeg.php
@@ -8,15 +8,43 @@ use PHPImageOptim\Tools\ToolsInterface;
 
 class MozJpeg extends Common implements ToolsInterface
 {
+    private $attributes = '';
+
+    public function __construct($options = ['quality' => 85])
+    {
+        $arguments = [];
+
+        foreach ($options as $key => $value) {
+            $arguments[] = sprintf('-%s %s', $key, $value);
+        }
+
+        $this->attributes = join(' ', $arguments);
+    }
+
     public function optimise()
     {
-        exec($this->binaryPath . ' -quality 90 ' . escapeshellarg($this->imagePath), $aOutput, $iResult);
+        $tempFile = tempnam(sys_get_temp_dir(), 'PHPImageOptim');
+        $command = sprintf(
+            $this->binaryPath . ' %s -outfile %s %s',
+            $this->attributes,
+            escapeshellarg($tempFile),
+            escapeshellarg($this->imagePath)
+        );
+
+        exec(
+            $command,
+            $aOutput,
+            $iResult
+        );
+
+        rename($tempFile, $this->imagePath);
 
         if ($iResult !== 0) {
             throw new Exception('MozJpeg was unable to optimise image.');
         }
         return $this;
     }
+
     public function checkVersion()
     {
         exec($this->binaryPath . ' --version', $aOutput, $iResult);


### PR DESCRIPTION
fixes #8.

MozJpeg can not be used on the same file as input and output so we need to create a temporarily file: https://github.com/mozilla/mozjpeg/issues/248