### PR TITLE
correction of the previous new option $stopIfFail

### DIFF
--- a/src/PHPImageOptim/PHPImageOptim.php
+++ b/src/PHPImageOptim/PHPImageOptim.php
@@ -35,8 +35,9 @@ class PHPImageOptim
      * @param $object
      * @return PHPImageOptim
      */
-    public function chainCommand($object): PHPImageOptim
+    public function chainCommand($object, $stopIfFail = true): PHPImageOptim
     {
+        $object->setStopIfFail($stopIfFail);
         $this->chainedCommands[] = $object;
         return $this;
     }
@@ -44,10 +45,8 @@ class PHPImageOptim
     /**
      * @return bool
      */
-    public function optimise($stopIfFail = true): bool
+    public function optimise(): bool
     {
-        $this->stopIfFail = $stopIfFail;
-        
         foreach ($this->chainedCommands as $chainedCommand) {
             $chainedCommand->determinePreOptimisedFileSize();
             $chainedCommand->setImagePath($this->imagePath);

--- a/src/PHPImageOptim/Tools/Common.php
+++ b/src/PHPImageOptim/Tools/Common.php
@@ -30,6 +30,17 @@ class Common
     }
 
     /**
+     * @param string $stopIfFail
+     * @return $this
+     * @throws Exception
+     */
+    public function setStopIfFail($stopIfFail)
+    {
+        $this->stopIfFail = boolval($stopIfFail);
+        return $this;
+    }
+
+    /**
      * @param $imagePath
      * @return $this
      * @throws Exception


### PR DESCRIPTION
Hello!
I incorrectly write the previous pull request introducing the new option $stopIfFail. This pull request will correct the issue.
The $stopIfFail option is now in the chainCommand() instead of the optimise(). It will now be possible to specify what commands you want to stop if fail.
Thank!